### PR TITLE
Fix: correct white space between emoji and map name using flex and gap

### DIFF
--- a/src/lib/list/maps.svelte
+++ b/src/lib/list/maps.svelte
@@ -47,9 +47,9 @@
 			<div class="maps flex flex-col justify-start items-start flex-wrap">
 				{#each node.maps as map}
 					<a class="map" href={map.url} onclick={(event: Event) => event.stopPropagation()}>
-						<div class="unselectable">
+						<div class="unselectable flex">
 							<div class="unselectable emoji">{@html emojis[map.emoji]}</div>
-							<span class="unselectable">&nbsp;&nbsp;&nbsp;&thinsp;&thinsp;&thinsp;{map.question.short}</span>
+							<span class="unselectable">{map.question.short}</span>
 						</div>
 					</a>
 				{/each}
@@ -138,5 +138,10 @@
 		line-height: 1.25em;
 		text-wrap: wrap;
 		color: #303037;
+	}
+
+	.map > .unselectable
+	{
+		gap: 0.3em;
 	}
 </style>


### PR DESCRIPTION
Fixes #121 

## ✏️ Changes
- Flex container + 0.3em gap

## Results 

### IOS 26.0 (iPhone 12 Mini)

Brave: 
<img width="300" height="auto" alt="IMG_6675" src="https://github.com/user-attachments/assets/c78d4e1a-b400-427f-8089-29f27a605619" />


Safari:
<img width="300" height="auto" alt="IMG_6676" src="https://github.com/user-attachments/assets/5759c3a7-6e7e-44bd-8e2e-0efce69b5eeb" />


### Ubuntu

Brave:
<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/e2fadca7-e560-4d4b-b87f-aa3406492312" />

Firefox:
<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/ae737316-06da-4e94-a291-d074151f4783" />


### Android

Chrome:
<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/f7e46d4a-baac-44a9-ae4d-a5211a1bab32" />

## 👤 Discord
`@Naykos`
